### PR TITLE
feat: my collection 의 video id 만 가져오기 api  완료

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -135,7 +135,13 @@ operation::post_join[snippets='http-request,request-headers,request-body,http-re
 
  내 곡 목록을 가져옵니다 (List of Video Response 형태)
 
-operation::user/get_my_collection[snippets='http-request,request-headers,request-parameters,http-response,response-fields,response-fields-data']
+operation::user/get_my_collection[snippets='http-request,request-headers,http-response,response-fields,response-fields-data']
+
+=== `GET` /user/my-collection-video-id-list
+
+내 곡 목록 데이터 중 video id 만 가져온 형태를 반환합니다
+
+operation::user/get_my_collection_video_id_list[snippets='http-request,request-headers,http-response,response-fields']
 
 === `POST` /user/my-collection/{videoId}
 

--- a/src/main/java/com/chordplay/chordplayapiserver/domain/user/api/UserApiController.java
+++ b/src/main/java/com/chordplay/chordplayapiserver/domain/user/api/UserApiController.java
@@ -76,4 +76,11 @@ public class UserApiController {
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 
+    @GetMapping("my-collection-video-id-list")
+    public ResponseEntity<ApiResponse<List<String>>> getMyCollectionVideoIdList(){
+        List<String> myCollectionVideoIdList = userService.getMyCollectionVideoIdList();
+        ApiResponse<List<String>> body = ApiResponse.success(myCollectionVideoIdList, HttpStatus.OK.value());
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
 }

--- a/src/main/java/com/chordplay/chordplayapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/chordplay/chordplayapiserver/domain/user/service/UserService.java
@@ -23,4 +23,5 @@ public interface UserService {
     void deleteVideoIdFromMyCollection(String videoId);
 
     List<VideoResponse> getMyCollection();
+    List<String> getMyCollectionVideoIdList();
 }

--- a/src/main/java/com/chordplay/chordplayapiserver/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/chordplay/chordplayapiserver/domain/user/service/UserServiceImpl.java
@@ -113,4 +113,16 @@ public class UserServiceImpl implements UserService{
 
         return myCollectionResponse;
     }
+
+    @Override
+    public List<String> getMyCollectionVideoIdList() {
+        List<String> videoIds = new ArrayList<>();
+        User user = getUser(ContextUtil.getPrincipalUserId());
+
+        if (user.getMyCollection() == null){
+            return videoIds;
+        }
+
+        return user.getMyCollection();
+    }
 }

--- a/src/main/resources/static/docs/api-guide.html
+++ b/src/main/resources/static/docs/api-guide.html
@@ -466,6 +466,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_post_usercheck_duplication"><code>POST</code> /user/check-duplication</a></li>
 <li><a href="#_post_userjoin"><code>POST</code> /user/join</a></li>
 <li><a href="#_get_usermy_collection"><code>GET</code> /user/my-collection</a></li>
+<li><a href="#_get_usermy_collection_video_id_list"><code>GET</code> /user/my-collection-video-id-list</a></li>
 <li><a href="#_post_usermy_collectionvideoid"><code>POST</code> /user/my-collection/{videoId}</a></li>
 <li><a href="#_delete_usermy_collectionvideoid"><code>Delete</code> /user/my-collection/{videoId}</a></li>
 </ul>
@@ -971,12 +972,6 @@ Host: api.baetles.site</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_get_usermy_collection_request_parameters"><a class="link" href="#_get_usermy_collection_request_parameters">Request parameters</a></h4>
-<div class="paragraph">
-<p>Snippet request-parameters not found for operation::user/get_my_collection</p>
-</div>
-</div>
-<div class="sect3">
 <h4 id="_get_usermy_collection_http_response"><a class="link" href="#_get_usermy_collection_http_response">Example response</a></h4>
 <div class="listingblock">
 <div class="content">
@@ -1108,6 +1103,94 @@ Content-Length: 428
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sheet_count</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">악보 조회수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_get_usermy_collection_video_id_list"><a class="link" href="#_get_usermy_collection_video_id_list"><code>GET</code> /user/my-collection-video-id-list</a></h3>
+<div class="paragraph">
+<p>내 곡 목록 데이터 중 video id 만 가져온 형태를 반환합니다</p>
+</div>
+<div class="sect3">
+<h4 id="_get_usermy_collection_video_id_list_http_request"><a class="link" href="#_get_usermy_collection_video_id_list_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /user/my-collection-video-id-list HTTP/1.1
+Accept: application/json
+Authorization: Bearer {token}
+Host: api.baetles.site</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_get_usermy_collection_video_id_list_request_headers"><a class="link" href="#_get_usermy_collection_video_id_list_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer {token}</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_get_usermy_collection_video_id_list_http_response"><a class="link" href="#_get_usermy_collection_video_id_list_http_response">Example response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 96
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : [ "videoId1", "videoId2", "videoId3" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_get_usermy_collection_video_id_list_response_fields"><a class="link" href="#_get_usermy_collection_video_id_list_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">my collection의 video id만 가져온 배열</p></td>
 </tr>
 </tbody>
 </table>
@@ -3722,7 +3805,7 @@ Content-Length: 918
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-10-15 04:20:55 +0900
+Last updated 2022-10-15 22:29:15 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/chordplay/chordplayapiserver/domain/user/api/UserApiControllerTest.java
+++ b/src/test/java/com/chordplay/chordplayapiserver/domain/user/api/UserApiControllerTest.java
@@ -32,6 +32,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.sql.Array;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,6 +170,23 @@ class UserApiControllerTest {
         result.andDo(UserTestDocs.documentOnGettingMyCollection());
     }
 
+    @Test
+    @DisplayName("my collection의 video Id list 가져오기_ _성공 반환(200)")
+    @WithMockCustomUser
+    public void getMyCollectionVideoIdListTest() throws Exception {
+
+        //get
+        List<String> myCollectionVideoIdList= Arrays.asList("videoId1","videoId2","videoId3");
+        given(userService.getMyCollectionVideoIdList()).willReturn(myCollectionVideoIdList);
+
+        //when
+        ResultActions result = getMyCollectionVideoIdList();
+
+        //then
+        verifyGettingMyCollectionVideoIdList(result);
+        result.andDo(UserTestDocs.documentOnGettingMyCollectionVideoIdList());
+    }
+
     private JoinRequest CreateMockJoinRequestBody() {
         return JoinRequest.builder()
                 .country(Country.KR)
@@ -248,6 +266,11 @@ class UserApiControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization","Bearer {token}"));
     }
+    private ResultActions getMyCollectionVideoIdList() throws Exception {
+        return mockMvc.perform(get("/user/my-collection-video-id-list")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization","Bearer {token}"));
+    }
     private void verifyOK(ResultActions result) throws Exception {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
@@ -267,6 +290,11 @@ class UserApiControllerTest {
     private ResultActions verifyGettingMyCollection(ResultActions result) throws Exception {
         verifyOK(result);
         return result.andExpect(jsonPath("$.data.length()").value(1));
+    }
+
+    private ResultActions verifyGettingMyCollectionVideoIdList(ResultActions result) throws Exception {
+        verifyOK(result);
+        return result.andExpect(jsonPath("$.data.length()").value(3));
     }
 
 }

--- a/src/test/java/com/chordplay/chordplayapiserver/domain/user/docs/UserTestDocs.java
+++ b/src/test/java/com/chordplay/chordplayapiserver/domain/user/docs/UserTestDocs.java
@@ -6,6 +6,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultHandler;
 
+import java.util.Arrays;
+
 import static com.chordplay.chordplayapiserver.util.ApiDocumentUtils.getDocumentRequest;
 import static com.chordplay.chordplayapiserver.util.ApiDocumentUtils.getDocumentResponse;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -22,6 +24,7 @@ public class UserTestDocs {
     private static String getNameOfDocsOfAddingVideoIdToMyCollection = "user/add_video_id_to_my_collection";
     private static String getNameOfDocsOfDeletingVideoIdFromMyCollection  = "user/delete_video_id_to_my_collection";
     private static String getNameOfDocsOfGettingMyCollection  = "user/get_my_collection";
+    private static String getNameOfDocsOfGettingMyCollectionVideoIdList  = "user/get_my_collection_video_id_list";
 
     public static ResultHandler documentOnLoginSuccess() {
         return document(getNameOfDocsOfLoginSuccess,
@@ -101,6 +104,21 @@ public class UserTestDocs {
                 ),
                 responseFields(CommonTestDocs.commonDocsOfArray()),
                 responseFields(beneathPath("data").withSubsectionId("data"),VideoTestDocs.videoResponse())
+        );
+    }
+
+    public static ResultHandler documentOnGettingMyCollectionVideoIdList() {
+        return document(getNameOfDocsOfGettingMyCollectionVideoIdList,
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                        headerWithName("Authorization").description("Bearer {token}")
+                ),
+                responseFields(Arrays.asList(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("결과 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메시지"),
+                        subsectionWithPath("data").type(JsonFieldType.ARRAY).description("my collection의 video id만 가져온 배열")
+                ))
         );
     }
 }


### PR DESCRIPTION
### 추가사항

내 곡 목록에 담았는지 FE에서 확인하는 절차를 위해 비디오 목록을 가져옴
비디오 객체 데이터를 모두 가져오는 것 보다 video id list 만 가져오는 것이 더 효율적이기 때문에 video id list만 가져오도록 함
- Docs 추가 완료
- controller unit test 추가 완료

### 참고사항